### PR TITLE
Add gulp-rename.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",
     "gulp-open": "^1.0.0",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "run-sequence": "^1.1.5"


### PR DESCRIPTION
Gulp-rename was required in the Gulpfile, but not included in the package.json file. 